### PR TITLE
Fix login and registration failed fetch

### DIFF
--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -1,5 +1,9 @@
 // Configuración de la API
-const API_BASE_URL = 'http://localhost:3000/api';
+// Usamos una ruta relativa para evitar problemas si el frontend **no** se sirve desde
+// http://localhost:3000 (por ejemplo cuando se despliega en producción, se accede desde
+// otra IP o se consulta a través de un túnel).  De esta forma la llamada se dirige al
+// mismo host donde se está sirviendo la aplicación, solo añadiendo el prefijo /api.
+const API_BASE_URL = '/api';
 
 // Clase para manejar errores de la API
 class ApiError extends Error {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Change API base URL to a relative path to fix "Failed to fetch" errors and improve deployment flexibility.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous hardcoded absolute URL `http://localhost:3000/api` caused "Failed to fetch" errors when the frontend was not served from that exact origin (e.g., in production, or if accessed via a different IP/port). Using a relative path `/api` ensures API calls are made to the same host serving the frontend, resolving issues related to incorrect host, mixed content, or unnecessary CORS.

---
<a href="https://cursor.com/background-agent?bcId=bc-35095172-2b2c-46fb-b7f8-a6d299f69b86">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-35095172-2b2c-46fb-b7f8-a6d299f69b86">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>